### PR TITLE
fix: miss-referenced error

### DIFF
--- a/internal/method/resolver.go
+++ b/internal/method/resolver.go
@@ -133,7 +133,10 @@ func singleResolutionCall(ref Reference, referencePkgPath string) resolutionCall
 			setResolvedValue = &jen.Statement{
 				jen.Var().Id(id).Op(ref.SourceType.String()),
 				jen.Line(),
-				jen.If(jen.Qual(referencePkgPath, "ToPtrValue").Call(jen.Id("rsp").Dot("ResolvedValue"), jen.Id(id)).Op("!=").Nil()).Block(
+				jen.If(
+					jen.Err().Op("=").Qual(referencePkgPath, "ToPtrValue").Call(jen.Id("rsp").Dot("ResolvedValue"), jen.Id(id)),
+					jen.Err().Op("!=").Nil(),
+				).Block(
 					jen.Return(jen.Qual("github.com/pkg/errors", "Wrap").Call(jen.Err(), jen.Lit(strings.Join(ref.GoValueFieldPath, ".")))),
 				),
 				jen.Line(),
@@ -189,7 +192,10 @@ func multiResolutionCall(ref Reference, referencePkgPath string) resolutionCallF
 			setResolvedValues = &jen.Statement{
 				jen.Id(id).Op(":=").Make(jen.Op(ref.SourceType.String()), jen.Len(jen.Id("mrsp").Dot("ResolvedValues"))),
 				jen.Line(),
-				jen.If(jen.Qual(referencePkgPath, "ToPtrValues").Call(jen.Id("mrsp").Dot("ResolvedValues"), jen.Id(id)).Op("!=").Nil()).Block(
+				jen.If(
+					jen.Err().Op("=").Qual(referencePkgPath, "ToPtrValues").Call(jen.Id("mrsp").Dot("ResolvedValues"), jen.Id(id)),
+					jen.Err().Op("!=").Nil(),
+				).Block(
 					jen.Return(jen.Qual("github.com/pkg/errors", "Wrap").Call(jen.Err(), jen.Lit(strings.Join(ref.GoValueFieldPath, ".")))),
 				),
 				jen.Line(),


### PR DESCRIPTION
Fixes an issue where generated code would swallow the exception during referencing and instead send a nil err variable to stderr.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
